### PR TITLE
[FIX]: Add dependence to account_invoice_tax

### DIFF
--- a/l10n_mx_facturae_pac_sf/__openerp__.py
+++ b/l10n_mx_facturae_pac_sf/__openerp__.py
@@ -44,6 +44,7 @@ Ubuntu Package Depends:
         "l10n_mx_facturae_pac",
         "l10n_mx_facturae_group_show_wizards",
         "l10n_mx_settings_facturae",
+        "account_invoice_tax"
         ],
     "demo" : [
         "demo/l10n_mx_facturae_pac_sf_demo.xml",


### PR DESCRIPTION
Without this dependence you cannot print account.invoice PDF
